### PR TITLE
Revert pending device orientation on failed rotation

### DIFF
--- a/WebDriverAgentLib/Commands/FBOrientationCommands.m
+++ b/WebDriverAgentLib/Commands/FBOrientationCommands.m
@@ -67,6 +67,14 @@ const struct FBWDOrientationValues FBWDOrientationValues = {
     return FBResponseWithOK();
   }
 
+  // The interface did not rotate but XCUIDevice keeps the requested device
+  // orientation pending, which would kick in once an app that supports it
+  // comes to the foreground. Revert it to the effective interface orientation.
+  NSString *effectiveOrientation = [self.class interfaceOrientationForApplication:application];
+  NSNumber *effectiveValue = [[self _orientationsMapping] objectForKey:effectiveOrientation];
+  if (effectiveValue != nil) {
+    [XCUIDevice sharedDevice].orientation = (UIDeviceOrientation)effectiveValue.integerValue;
+  }
   return FBResponseWithUnknownErrorFormat(@"Unable To Rotate Device");
 }
 


### PR DESCRIPTION
When a rotation request fails, `XCUIDevice` keeps the requested orientation pending and would apply it as soon as an app that supports it comes to the foreground. Reset it to the effective interface orientation before returning the error to avoid unexpected rotations later.